### PR TITLE
fix: add missing pyproject.toml files for module packaging

### DIFF
--- a/modules/hooks-ts-check/pyproject.toml
+++ b/modules/hooks-ts-check/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "amplifier-module-hooks-ts-check"
+version = "0.1.0"
+description = "Auto-checking hook for TypeScript/JavaScript files in Amplifier"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Microsoft", email = "amplifier@microsoft.com" }]
+dependencies = []  # amplifier-core is a peer dependency
+
+[project.entry-points."amplifier.modules"]
+hooks-ts-check = "amplifier_module_hooks_ts_check:mount"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["amplifier_module_hooks_ts_check"]

--- a/modules/tool-ts-check/pyproject.toml
+++ b/modules/tool-ts-check/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "amplifier-module-tool-ts-check"
+version = "0.1.0"
+description = "TypeScript/JavaScript code quality checking tool for Amplifier"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Microsoft", email = "amplifier@microsoft.com" }]
+dependencies = []  # amplifier-core is a peer dependency
+
+[project.entry-points."amplifier.modules"]
+tool-ts-check = "amplifier_module_tool_ts_check:mount"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["amplifier_module_tool_ts_check"]


### PR DESCRIPTION
## Summary

This PR adds missing `pyproject.toml` files to the module directories, enabling them to be installed via git+https:// URLs.

## Changes

### New files:
- `modules/tool-ts-check/pyproject.toml`
- `modules/hooks-ts-check/pyproject.toml`

Both modules now have proper hatchling build configuration with:
- Entry points for `amplifier.modules`
- Correct package paths
- No invalid dependencies

## Testing

✅ Shadow environment testing passed (100/100):
- Both modules build into wheels successfully
- Both modules install without errors
- Both modules import with `mount` function available

---
🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
